### PR TITLE
[codex] speed up export extraction

### DIFF
--- a/src/bundles/bundle.rs
+++ b/src/bundles/bundle.rs
@@ -1,6 +1,6 @@
-use std::io::{self, Read, Seek, SeekFrom};
-use byteorder::{ByteOrder, LittleEndian};
 use crate::ooz::sys::Ooz_Decompress;
+use byteorder::{ByteOrder, LittleEndian};
+use std::io::{self, Read, Seek, SeekFrom};
 use std::ptr;
 
 pub struct Bundle {
@@ -20,12 +20,11 @@ impl Bundle {
     pub fn read_header<R: Read + Seek>(mut reader: R) -> io::Result<Self> {
         let mut header = [0u8; 60];
         reader.read_exact(&mut header)?;
-        
+
         let uncompressed_size = LittleEndian::read_u32(&header[0..4]);
         let total_payload_size = LittleEndian::read_u32(&header[4..8]);
         let head_payload_size = LittleEndian::read_u32(&header[8..12]);
         let first_file_encode = LittleEndian::read_u32(&header[12..16]);
-        println!("Bundle Header: Compressor Type = {}", first_file_encode);
         // unk10 at 16..20
         let uncompressed_size2 = LittleEndian::read_u64(&header[20..28]);
         let total_payload_size2 = LittleEndian::read_u64(&header[28..36]);
@@ -36,12 +35,13 @@ impl Bundle {
         let mut block_sizes = Vec::with_capacity(block_count as usize);
         let mut block_sizes_buf = vec![0u8; (block_count * 4) as usize];
         reader.read_exact(&mut block_sizes_buf)?;
-        
+
         for i in 0..block_count {
-            let size = LittleEndian::read_u32(&block_sizes_buf[(i as usize)*4..((i as usize)+1)*4]);
+            let size =
+                LittleEndian::read_u32(&block_sizes_buf[(i as usize) * 4..((i as usize) + 1) * 4]);
             block_sizes.push(size);
         }
-        
+
         let data_offset = reader.stream_position()?;
 
         Ok(Self {
@@ -69,37 +69,112 @@ impl Bundle {
         let mut output = vec![0u8; size + SAFE_SPACE];
         let output_ptr = output.as_mut_ptr();
         let mut output_offset = 0;
-        
+
         reader.seek(SeekFrom::Start(self.data_offset))?;
-        
+
         for &block_size in &self.block_sizes {
             let mut compressed_data = vec![0u8; block_size as usize];
             reader.read_exact(&mut compressed_data)?;
-            
+
             // Determine decompressed size for this block
             // Usually 256KB, except last one.
             let remaining = self.uncompressed_size as usize - output_offset;
             let dst_len = std::cmp::min(remaining, self.chunk_size as usize);
-            
+
             let ret = unsafe {
                 Ooz_Decompress(
                     compressed_data.as_ptr(),
                     block_size as i32,
                     output_ptr.add(output_offset),
                     dst_len,
-                    0, 0, 0,
-                    ptr::null_mut(), 0, ptr::null_mut(), ptr::null_mut(),
-                    ptr::null_mut(), 0, 0
+                    0,
+                    0,
+                    0,
+                    ptr::null_mut(),
+                    0,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    0,
+                    0,
                 )
             };
-            
+
             if ret != dst_len as i32 {
                 println!("Ooz_Decompress FAILED: ret={}, dst_len={}", ret, dst_len);
-                return Err(io::Error::new(io::ErrorKind::InvalidData, format!("Ooz_Decompress failed: returned {}, expected {}", ret, dst_len)));
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Ooz_Decompress failed: returned {}, expected {}",
+                        ret, dst_len
+                    ),
+                ));
             } else {
                 // println!("Ooz_Decompress success: {}", ret);
             }
-            
+
+            output_offset += dst_len;
+        }
+
+        output.truncate(size);
+        Ok(output)
+    }
+
+    pub fn decompress_from_slice(&self, data: &[u8]) -> io::Result<Vec<u8>> {
+        const SAFE_SPACE: usize = 64;
+        let size = self.uncompressed_size as usize;
+        let mut output = vec![0u8; size + SAFE_SPACE];
+        let output_ptr = output.as_mut_ptr();
+        let mut output_offset = 0;
+        let mut input_offset = self.data_offset as usize;
+
+        for &block_size in &self.block_sizes {
+            let block_size = block_size as usize;
+            let input_end = input_offset.checked_add(block_size).ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidData, "Block offset overflow")
+            })?;
+            if input_end > data.len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "Compressed block out of bounds",
+                ));
+            }
+            let compressed_data = &data[input_offset..input_end];
+
+            let remaining = self.uncompressed_size as usize - output_offset;
+            let dst_len = std::cmp::min(remaining, self.chunk_size as usize);
+
+            let ret = unsafe {
+                Ooz_Decompress(
+                    compressed_data.as_ptr(),
+                    block_size as i32,
+                    output_ptr.add(output_offset),
+                    dst_len,
+                    0,
+                    0,
+                    0,
+                    ptr::null_mut(),
+                    0,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    0,
+                    0,
+                )
+            };
+
+            if ret != dst_len as i32 {
+                println!("Ooz_Decompress FAILED: ret={}, dst_len={}", ret, dst_len);
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "Ooz_Decompress failed: returned {}, expected {}",
+                        ret, dst_len
+                    ),
+                ));
+            }
+
+            input_offset = input_end;
             output_offset += dst_len;
         }
 
@@ -108,3 +183,26 @@ impl Bundle {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decompress_from_slice_rejects_truncated_block_payload() {
+        let bundle = Bundle {
+            uncompressed_size: 1,
+            total_payload_size: 0,
+            head_payload_size: 0,
+            first_file_encode: 0,
+            uncompressed_size2: 0,
+            total_payload_size2: 0,
+            block_count: 1,
+            chunk_size: 1,
+            block_sizes: vec![4],
+            data_offset: 2,
+        };
+
+        let err = bundle.decompress_from_slice(&[0, 0, 1]).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::UnexpectedEof);
+    }
+}

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,15 +1,24 @@
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, mpsc::Sender};
-use std::sync::atomic::AtomicBool;
-use crate::ggpk::reader::GgpkReader;
 use crate::bundles::index::Index as BundleIndex;
-use crate::ui::export_window::{ExportSettings, TextureFormat, AudioFormat, DataFormat, PsgFormat};
 use crate::dat::schema::Schema;
+use crate::ggpk::reader::GgpkReader;
+use crate::ui::export_window::{AudioFormat, DataFormat, ExportSettings, PsgFormat, TextureFormat};
+use std::collections::{HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{mpsc::Sender, Arc, Mutex};
 
 #[derive(Debug, Clone)]
 pub enum ExportStatus {
-    Progress { current: usize, total: usize, filename: String },
-    Complete { count: usize, errors: usize, message: String },
+    Progress {
+        current: usize,
+        total: usize,
+        filename: String,
+    },
+    Complete {
+        count: usize,
+        errors: usize,
+        message: String,
+    },
     Error(String),
 }
 
@@ -19,13 +28,72 @@ struct BundleCache {
     entries: Vec<(u32, Vec<u8>)>,
 }
 
+struct DirectoryCache {
+    created: HashSet<PathBuf>,
+}
+
+impl DirectoryCache {
+    fn new() -> Self {
+        Self {
+            created: HashSet::new(),
+        }
+    }
+}
+
+fn mark_parent_dir_created(path: &Path, cache: &mut DirectoryCache) -> bool {
+    path.parent()
+        .map(|parent| cache.created.insert(parent.to_path_buf()))
+        .unwrap_or(false)
+}
+
+fn ensure_parent_dir(path: &Path, cache: &mut DirectoryCache) -> Result<(), String> {
+    if mark_parent_dir_created(path, cache) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
+}
+
+struct ProgressLimiter {
+    interval: usize,
+}
+
+impl ProgressLimiter {
+    fn new(interval: usize) -> Self {
+        Self {
+            interval: interval.max(1),
+        }
+    }
+
+    fn should_send(&self, current: usize, total: usize) -> bool {
+        current == total || current == 1 || current % self.interval == 0
+    }
+}
+
+enum RawBundleData<'a> {
+    Borrowed(&'a [u8]),
+    Owned(Vec<u8>),
+}
+
+impl<'a> RawBundleData<'a> {
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Borrowed(data) => data,
+            Self::Owned(data) => data,
+        }
+    }
+}
+
 impl BundleCache {
     // Two entries is enough once hashes are sorted by bundle; the second
     // slot absorbs files whose paths interleave two bundles.
     const MAX_ENTRIES: usize = 2;
 
     fn new() -> Self {
-        Self { entries: Vec::new() }
+        Self {
+            entries: Vec::new(),
+        }
     }
 
     fn get(&mut self, bundle_index: u32) -> Option<&[u8]> {
@@ -45,6 +113,54 @@ impl BundleCache {
     }
 }
 
+#[derive(Debug, Clone)]
+struct ExportWorkGroup {
+    #[allow(dead_code)]
+    bundle_index: u32,
+    hashes: Vec<u64>,
+}
+
+fn build_export_work_groups(mut hashes: Vec<u64>, index: &BundleIndex) -> Vec<ExportWorkGroup> {
+    hashes.sort_by_key(|h| {
+        index
+            .files
+            .get(h)
+            .map(|f| (f.bundle_index, f.file_offset))
+            .unwrap_or((u32::MAX, 0))
+    });
+
+    let mut groups: Vec<ExportWorkGroup> = Vec::new();
+    for hash in hashes {
+        let bundle_index = index
+            .files
+            .get(&hash)
+            .map(|f| f.bundle_index)
+            .unwrap_or(u32::MAX);
+
+        if let Some(group) = groups.last_mut() {
+            if group.bundle_index == bundle_index {
+                group.hashes.push(hash);
+                continue;
+            }
+        }
+
+        groups.push(ExportWorkGroup {
+            bundle_index,
+            hashes: vec![hash],
+        });
+    }
+
+    groups
+}
+
+fn export_worker_count(group_count: usize) -> usize {
+    let available = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(1);
+
+    available.min(32).min(group_count.max(1))
+}
+
 pub fn run_export(
     hashes: Vec<u64>,
     reader: Option<Arc<GgpkReader>>,
@@ -55,31 +171,47 @@ pub fn run_export(
     steam_loader: Option<crate::bundles::steam::SteamBundleLoader>,
     schema: Option<Schema>,
     tx: Sender<ExportStatus>,
-    _cancel_flag: Option<Arc<AtomicBool>>, // Future proofing for cancellation
+    cancel_flag: Option<Arc<AtomicBool>>,
 ) {
     let total = hashes.len();
+    if let Some(index) = bundle_index {
+        let groups = build_export_work_groups(hashes, &index);
+        run_grouped_export(
+            groups,
+            total,
+            reader,
+            index,
+            settings,
+            target_dir,
+            cdn_loader,
+            steam_loader,
+            schema,
+            tx,
+            cancel_flag,
+        );
+        return;
+    }
+
     let mut success_count = 0;
     let mut error_count = 0;
     let mut errors = Vec::new();
     let mut error_log: Option<std::fs::File> = None;
     let mut bundle_cache = BundleCache::new();
-
-    // Group files by bundle so each bundle is decompressed once, not once
-    // per contained file.
-    let mut hashes = hashes;
-    if let Some(idx) = &bundle_index {
-        hashes.sort_by_key(|h| {
-            idx.files
-                .get(h)
-                .map(|f| (f.bundle_index, f.file_offset))
-                .unwrap_or((u32::MAX, 0))
-        });
-    }
+    let mut directory_cache = DirectoryCache::new();
+    let progress_limiter = ProgressLimiter::new(64);
 
     for (i, hash) in hashes.iter().enumerate() {
+        if cancel_flag
+            .as_ref()
+            .map(|flag| flag.load(Ordering::Relaxed))
+            .unwrap_or(false)
+        {
+            break;
+        }
+
         // Send progress
         // We can't know the exact filename easily without looking it up, but we'll try to get it inside the loop
-        
+
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             match export_single_file(
                 *hash,
@@ -91,6 +223,7 @@ pub fn run_export(
                 &steam_loader,
                 &schema,
                 &mut bundle_cache,
+                &mut directory_cache,
             ) {
                 Ok(name) => Ok(name),
                 Err(e) => Err(format!("Export failed: {}", e)),
@@ -100,22 +233,24 @@ pub fn run_export(
         match result {
             Ok(Ok(filename)) => {
                 success_count += 1;
-                 let _ = tx.send(ExportStatus::Progress { 
-                    current: i + 1, 
-                    total, 
-                    filename 
-                });
-            },
+                if progress_limiter.should_send(i + 1, total) {
+                    let _ = tx.send(ExportStatus::Progress {
+                        current: i + 1,
+                        total,
+                        filename,
+                    });
+                }
+            }
             Ok(Err(e)) => {
                 error_count += 1;
                 errors.push(e.clone());
                 append_error_log(&mut error_log, &target_dir, &e);
-                 let _ = tx.send(ExportStatus::Progress {
+                let _ = tx.send(ExportStatus::Progress {
                     current: i + 1,
                     total,
-                    filename: format!("Error: {}", e)
+                    filename: format!("Error: {}", e),
                 });
-            },
+            }
             Err(payload) => {
                 error_count += 1;
                 let msg = if let Some(s) = payload.downcast_ref::<&str>() {
@@ -127,10 +262,10 @@ pub fn run_export(
                 };
                 errors.push(msg.clone());
                 append_error_log(&mut error_log, &target_dir, &msg);
-                 let _ = tx.send(ExportStatus::Progress {
+                let _ = tx.send(ExportStatus::Progress {
                     current: i + 1,
                     total,
-                    filename: msg
+                    filename: msg,
                 });
             }
         }
@@ -139,9 +274,12 @@ pub fn run_export(
     let final_msg = if error_count == 0 {
         format!("Successfully exported {} files.", success_count)
     } else {
-        format!("Exported {} files. {} errors occurred.", success_count, error_count)
+        format!(
+            "Exported {} files. {} errors occurred.",
+            success_count, error_count
+        )
     };
-    
+
     // Errors were appended to export_errors.log as they happened (so a crash
     // mid-export still leaves a log); finish with a summary line.
     if error_count > 0 {
@@ -150,16 +288,197 @@ pub fn run_export(
             &target_dir,
             &format!("--- {} of {} files failed ---", error_count, total),
         );
-        println!("Export Errors (also in {}):", target_dir.join("export_errors.log").display());
+        println!(
+            "Export Errors (also in {}):",
+            target_dir.join("export_errors.log").display()
+        );
         for e in &errors {
             println!("  - {}", e);
         }
     }
 
-    let _ = tx.send(ExportStatus::Complete { 
-        count: success_count, 
-        errors: error_count, 
-        message: final_msg 
+    let _ = tx.send(ExportStatus::Complete {
+        count: success_count,
+        errors: error_count,
+        message: final_msg,
+    });
+}
+
+fn run_grouped_export(
+    groups: Vec<ExportWorkGroup>,
+    total: usize,
+    reader: Option<Arc<GgpkReader>>,
+    bundle_index: Arc<BundleIndex>,
+    settings: ExportSettings,
+    target_dir: PathBuf,
+    cdn_loader: Option<crate::bundles::cdn::CdnBundleLoader>,
+    steam_loader: Option<crate::bundles::steam::SteamBundleLoader>,
+    schema: Option<Schema>,
+    tx: Sender<ExportStatus>,
+    cancel_flag: Option<Arc<AtomicBool>>,
+) {
+    let worker_count = export_worker_count(groups.len());
+    let work_queue = Arc::new(Mutex::new(VecDeque::from(groups)));
+    let completed_count = Arc::new(AtomicUsize::new(0));
+    let success_count = Arc::new(AtomicUsize::new(0));
+    let error_count = Arc::new(AtomicUsize::new(0));
+    let errors = Arc::new(Mutex::new(Vec::new()));
+    let error_log = Arc::new(Mutex::new(None));
+    let target_dir = Arc::new(target_dir);
+    let settings = Arc::new(settings);
+    let schema = Arc::new(schema);
+    let cdn_loader = Arc::new(cdn_loader);
+    let steam_loader = Arc::new(steam_loader);
+
+    let mut workers = Vec::with_capacity(worker_count);
+    for _ in 0..worker_count {
+        let work_queue = Arc::clone(&work_queue);
+        let completed_count = Arc::clone(&completed_count);
+        let success_count = Arc::clone(&success_count);
+        let error_count = Arc::clone(&error_count);
+        let errors = Arc::clone(&errors);
+        let error_log = Arc::clone(&error_log);
+        let target_dir = Arc::clone(&target_dir);
+        let settings = Arc::clone(&settings);
+        let schema = Arc::clone(&schema);
+        let cdn_loader = Arc::clone(&cdn_loader);
+        let steam_loader = Arc::clone(&steam_loader);
+        let reader = reader.clone();
+        let bundle_index = Arc::clone(&bundle_index);
+        let tx = tx.clone();
+        let cancel_flag = cancel_flag.clone();
+
+        workers.push(std::thread::spawn(move || {
+            let mut bundle_cache = BundleCache::new();
+            let mut directory_cache = DirectoryCache::new();
+            let progress_limiter = ProgressLimiter::new(64);
+
+            loop {
+                if cancel_flag
+                    .as_ref()
+                    .map(|flag| flag.load(Ordering::Relaxed))
+                    .unwrap_or(false)
+                {
+                    break;
+                }
+
+                let group = {
+                    let mut queue = work_queue.lock().unwrap();
+                    queue.pop_front()
+                };
+
+                let Some(group) = group else {
+                    break;
+                };
+
+                for hash in group.hashes {
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        export_single_file(
+                            hash,
+                            reader.as_deref(),
+                            Some(bundle_index.as_ref()),
+                            &settings,
+                            &target_dir,
+                            cdn_loader.as_ref(),
+                            steam_loader.as_ref(),
+                            schema.as_ref(),
+                            &mut bundle_cache,
+                            &mut directory_cache,
+                        )
+                        .map_err(|e| format!("Export failed: {}", e))
+                    }));
+
+                    let current = completed_count.fetch_add(1, Ordering::Relaxed) + 1;
+                    match result {
+                        Ok(Ok(filename)) => {
+                            success_count.fetch_add(1, Ordering::Relaxed);
+                            if progress_limiter.should_send(current, total) {
+                                let _ = tx.send(ExportStatus::Progress {
+                                    current,
+                                    total,
+                                    filename,
+                                });
+                            }
+                        }
+                        Ok(Err(e)) => {
+                            error_count.fetch_add(1, Ordering::Relaxed);
+                            if let Ok(mut list) = errors.lock() {
+                                list.push(e.clone());
+                            }
+                            if let Ok(mut log) = error_log.lock() {
+                                append_error_log(&mut log, &target_dir, &e);
+                            }
+                            let _ = tx.send(ExportStatus::Progress {
+                                current,
+                                total,
+                                filename: format!("Error: {}", e),
+                            });
+                        }
+                        Err(payload) => {
+                            error_count.fetch_add(1, Ordering::Relaxed);
+                            let msg = if let Some(s) = payload.downcast_ref::<&str>() {
+                                format!("PANIC: {}", s)
+                            } else if let Some(s) = payload.downcast_ref::<String>() {
+                                format!("PANIC: {}", s)
+                            } else {
+                                "PANIC: Unknown error".to_string()
+                            };
+                            if let Ok(mut list) = errors.lock() {
+                                list.push(msg.clone());
+                            }
+                            if let Ok(mut log) = error_log.lock() {
+                                append_error_log(&mut log, &target_dir, &msg);
+                            }
+                            let _ = tx.send(ExportStatus::Progress {
+                                current,
+                                total,
+                                filename: msg,
+                            });
+                        }
+                    }
+                }
+            }
+        }));
+    }
+
+    for worker in workers {
+        let _ = worker.join();
+    }
+
+    let success_count = success_count.load(Ordering::Relaxed);
+    let error_count = error_count.load(Ordering::Relaxed);
+    let final_msg = if error_count == 0 {
+        format!("Successfully exported {} files.", success_count)
+    } else {
+        format!(
+            "Exported {} files. {} errors occurred.",
+            success_count, error_count
+        )
+    };
+
+    if error_count > 0 {
+        if let Ok(mut log) = error_log.lock() {
+            append_error_log(
+                &mut log,
+                &target_dir,
+                &format!("--- {} of {} files failed ---", error_count, total),
+            );
+        }
+        if let Ok(errors) = errors.lock() {
+            println!(
+                "Export Errors (also in {}):",
+                target_dir.join("export_errors.log").display()
+            );
+            for e in errors.iter() {
+                println!("  - {}", e);
+            }
+        }
+    }
+
+    let _ = tx.send(ExportStatus::Complete {
+        count: success_count,
+        errors: error_count,
+        message: final_msg,
     });
 }
 
@@ -178,7 +497,10 @@ mod tests {
         let reader = Arc::new(GgpkReader::open(&ggpk_path).unwrap());
 
         let cache_path = crate::settings::AppSettings::get_app_data_dir().join("bundles2.cache");
-        let index = Arc::new(BundleIndex::load_from_cache(&cache_path).expect("run the app once to build the index cache"));
+        let index = Arc::new(
+            BundleIndex::load_from_cache(&cache_path)
+                .expect("run the app once to build the index cache"),
+        );
 
         let hashes: Vec<u64> = index
             .files
@@ -214,12 +536,83 @@ mod tests {
         }
         println!("export took {:?}", t.elapsed());
         match last {
-            Some(ExportStatus::Complete { count, errors, message }) => {
-                println!("complete: {} exported, {} errors — {}", count, errors, message);
+            Some(ExportStatus::Complete {
+                count,
+                errors,
+                message,
+            }) => {
+                println!(
+                    "complete: {} exported, {} errors — {}",
+                    count, errors, message
+                );
                 assert!(count > 0);
             }
             other => panic!("export did not complete: {:?}", other),
         }
+    }
+
+    #[test]
+    fn groups_bundle_exports_by_bundle_index() {
+        let mut index = BundleIndex {
+            bundles: Vec::new(),
+            files: std::collections::HashMap::new(),
+        };
+        index.files.insert(
+            10,
+            crate::bundles::index::FileInfo {
+                path_hash: 10,
+                bundle_index: 2,
+                file_offset: 30,
+                file_size: 1,
+                path: "c".to_string(),
+            },
+        );
+        index.files.insert(
+            20,
+            crate::bundles::index::FileInfo {
+                path_hash: 20,
+                bundle_index: 1,
+                file_offset: 20,
+                file_size: 1,
+                path: "b".to_string(),
+            },
+        );
+        index.files.insert(
+            30,
+            crate::bundles::index::FileInfo {
+                path_hash: 30,
+                bundle_index: 1,
+                file_offset: 10,
+                file_size: 1,
+                path: "a".to_string(),
+            },
+        );
+
+        let groups = build_export_work_groups(vec![10, 20, 30], &index);
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].hashes, vec![30, 20]);
+        assert_eq!(groups[1].hashes, vec![10]);
+    }
+
+    #[test]
+    fn progress_limiter_sends_first_interval_and_final_updates() {
+        let limiter = ProgressLimiter::new(4);
+
+        assert!(limiter.should_send(1, 10));
+        assert!(!limiter.should_send(2, 10));
+        assert!(limiter.should_send(4, 10));
+        assert!(!limiter.should_send(9, 10));
+        assert!(limiter.should_send(10, 10));
+    }
+
+    #[test]
+    fn directory_cache_tracks_created_parent_paths() {
+        let mut cache = DirectoryCache::new();
+        let path = PathBuf::from("a/b/c.txt");
+
+        assert!(mark_parent_dir_created(&path, &mut cache));
+        assert!(!mark_parent_dir_created(&path, &mut cache));
     }
 }
 
@@ -250,9 +643,13 @@ fn export_single_file(
     steam_loader: &Option<crate::bundles::steam::SteamBundleLoader>,
     schema: &Option<Schema>,
     bundle_cache: &mut BundleCache,
+    directory_cache: &mut DirectoryCache,
 ) -> Result<String, String> {
-    let (path_str, file_data) = if let Some(idx) = bundle_index {
-        let file_info = idx.files.get(&hash).ok_or("File hash not found in bundle index")?;
+    if let Some(idx) = bundle_index {
+        let file_info = idx
+            .files
+            .get(&hash)
+            .ok_or("File hash not found in bundle index")?;
         let path = file_info.path.clone();
 
         if file_info.bundle_index == crate::bundles::index::GGPK_LOOSE_FILE_SENTINEL {
@@ -263,20 +660,22 @@ fn export_single_file(
                 .ok_or_else(|| format!("Loose GGPK file not found: {}", path))?;
             let bytes = r
                 .get_data_slice(rec.data_offset, rec.data_length)
-                .map_err(|e| format!("Failed to read loose GGPK file data: {}", e))?
-                .to_vec();
-            (path, bytes)
+                .map_err(|e| format!("Failed to read loose GGPK file data: {}", e))?;
+            export_file_data(&path, bytes, settings, target_dir, schema, directory_cache)?;
+            Ok(path)
         } else if file_info.bundle_index == crate::bundles::steam::LOOSE_FILE_SENTINEL {
             if let Some(steam) = steam_loader {
                 if let Some(loose_path) = steam.loose_file_path(&path) {
-                    let bytes = std::fs::read(&loose_path)
-                        .map_err(|e| format!("Failed to read loose file {}: {}", loose_path.display(), e))?;
-                    (path, bytes)
+                    let bytes = std::fs::read(&loose_path).map_err(|e| {
+                        format!("Failed to read loose file {}: {}", loose_path.display(), e)
+                    })?;
+                    export_file_data(&path, &bytes, settings, target_dir, schema, directory_cache)?;
+                    Ok(path)
                 } else {
-                    return Err(format!("Loose file not found on disk: {}", path));
+                    Err(format!("Loose file not found on disk: {}", path))
                 }
             } else {
-                return Err("Steam loader unavailable for loose-file export".to_string());
+                Err("Steam loader unavailable for loose-file export".to_string())
             }
         } else {
             let bundle_info = idx
@@ -286,18 +685,21 @@ fn export_single_file(
 
             if bundle_cache.get(file_info.bundle_index).is_none() {
                 let mut raw_bundle_data = None;
-                let candidates = vec![
-                    format!("Bundles2/{}", bundle_info.name),
-                    format!("Bundles2/{}.bundle.bin", bundle_info.name),
-                    bundle_info.name.clone(),
-                    format!("{}.bundle.bin", bundle_info.name),
-                ];
 
                 if let Some(r) = reader {
+                    let candidates = vec![
+                        format!("Bundles2/{}", bundle_info.name),
+                        format!("Bundles2/{}.bundle.bin", bundle_info.name),
+                        bundle_info.name.clone(),
+                        format!("{}.bundle.bin", bundle_info.name),
+                    ];
+
                     for cand in &candidates {
                         if let Ok(Some(file_record)) = r.read_file_by_path(cand) {
-                            if let Ok(data) = r.get_data_slice(file_record.data_offset, file_record.data_length) {
-                                raw_bundle_data = Some(data.to_vec());
+                            if let Ok(data) =
+                                r.get_data_slice(file_record.data_offset, file_record.data_length)
+                            {
+                                raw_bundle_data = Some(RawBundleData::Borrowed(data));
                                 break;
                             }
                         }
@@ -307,7 +709,7 @@ fn export_single_file(
                 if raw_bundle_data.is_none() {
                     if let Some(steam) = steam_loader {
                         if let Ok(data) = steam.fetch_bundle(&bundle_info.name) {
-                            raw_bundle_data = Some(data);
+                            raw_bundle_data = Some(RawBundleData::Owned(data));
                         }
                     }
                 }
@@ -320,17 +722,19 @@ fn export_single_file(
                             format!("{}.bundle.bin", bundle_info.name)
                         };
                         if let Ok(data) = cdn.fetch_bundle(&fetch_name) {
-                            raw_bundle_data = Some(data);
+                            raw_bundle_data = Some(RawBundleData::Owned(data));
                         }
                     }
                 }
 
-                let data = raw_bundle_data.ok_or("Failed to load bundle data (local, Steam, or CDN)")?;
+                let raw_bundle_data =
+                    raw_bundle_data.ok_or("Failed to load bundle data (local, Steam, or CDN)")?;
+                let data = raw_bundle_data.as_slice();
                 let mut cursor = std::io::Cursor::new(data);
                 let bundle = crate::bundles::bundle::Bundle::read_header(&mut cursor)
                     .map_err(|e| format!("Bundle Header: {}", e))?;
                 let decompressed_data = bundle
-                    .decompress(&mut cursor)
+                    .decompress_from_slice(data)
                     .map_err(|e| format!("Decompress: {}", e))?;
                 bundle_cache.insert(file_info.bundle_index, decompressed_data);
             }
@@ -350,7 +754,15 @@ fn export_single_file(
                 ));
             }
 
-            (path, decompressed_data[start..end].to_vec())
+            export_file_data(
+                &path,
+                &decompressed_data[start..end],
+                settings,
+                target_dir,
+                schema,
+                directory_cache,
+            )?;
+            Ok(path)
         }
     } else {
         let r = reader.ok_or("GGPK reader is required for raw export")?;
@@ -359,28 +771,40 @@ fn export_single_file(
             .map_err(|e| format!("Failed to read GGPK file record at offset {}: {}", hash, e))?;
         let bytes = r
             .get_data_slice(file.data_offset, file.data_length)
-            .map_err(|e| format!("Failed to read GGPK file data: {}", e))?
-            .to_vec();
-        (file.name, bytes)
-    };
+            .map_err(|e| format!("Failed to read GGPK file data: {}", e))?;
+        export_file_data(
+            &file.name,
+            bytes,
+            settings,
+            target_dir,
+            schema,
+            directory_cache,
+        )?;
+        Ok(file.name)
+    }
+}
 
+fn export_file_data(
+    path_str: &str,
+    file_data: &[u8],
+    settings: &ExportSettings,
+    target_dir: &Path,
+    schema: &Option<Schema>,
+    directory_cache: &mut DirectoryCache,
+) -> Result<(), String> {
     let relative_path = std::path::Path::new(&path_str);
     let full_path = target_dir.join(relative_path);
-    
-    if let Some(parent) = full_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    
+
+    ensure_parent_dir(&full_path, directory_cache)?;
+
     // File Extension Handling
-    let filename_display = path_str.clone();
     let path_lower = path_str.to_ascii_lowercase();
 
-    
     if path_lower.ends_with(".dds") {
         match settings.texture_format {
             TextureFormat::WebP => {
                 let mut converted = false;
-                let mut cursor = std::io::Cursor::new(&file_data);
+                let mut cursor = std::io::Cursor::new(file_data);
                 if let Ok(dds) = ddsfile::Dds::read(&mut cursor) {
                     if let Ok(image) = image_dds::image_from_dds(&dds, 0) {
                         let img = image::DynamicImage::ImageRgba8(image);
@@ -391,12 +815,12 @@ fn export_single_file(
                     }
                 }
                 if !converted {
-                    std::fs::write(&full_path, &file_data).map_err(|e| e.to_string())?;
+                    std::fs::write(&full_path, file_data).map_err(|e| e.to_string())?;
                 }
-            },
+            }
             TextureFormat::Png => {
                 let mut converted = false;
-                let mut cursor = std::io::Cursor::new(&file_data);
+                let mut cursor = std::io::Cursor::new(file_data);
                 if let Ok(dds) = ddsfile::Dds::read(&mut cursor) {
                     if let Ok(image) = image_dds::image_from_dds(&dds, 0) {
                         let img = image::DynamicImage::ImageRgba8(image);
@@ -407,104 +831,128 @@ fn export_single_file(
                     }
                 }
                 if !converted {
-                    std::fs::write(&full_path, &file_data).map_err(|e| e.to_string())?;
+                    std::fs::write(&full_path, file_data).map_err(|e| e.to_string())?;
                 }
-            },
+            }
             TextureFormat::OriginalDds => {
-                 std::fs::write(&full_path, &file_data).map_err(|e| e.to_string())?;
+                std::fs::write(&full_path, file_data).map_err(|e| e.to_string())?;
             }
         }
-    } else if path_lower.ends_with(".ogg") { 
-         match settings.audio_format {
-             AudioFormat::Wav => {
-                 let cursor = std::io::Cursor::new(file_data.clone());
-                 if let Ok(source) = rodio::Decoder::new(cursor) {
-                      use rodio::Source;
-                      let spec = hound::WavSpec {
-                          channels: source.channels(),
-                          sample_rate: source.sample_rate(),
-                          bits_per_sample: 16,
-                          sample_format: hound::SampleFormat::Int,
-                      };
-                      let dest = full_path.with_extension("wav");
-                      let mut writer = hound::WavWriter::create(dest, spec).map_err(|e| e.to_string())?;
-                      for sample in source {
-                          let _ = writer.write_sample(sample);
-                      }
-                      writer.finalize().map_err(|e| e.to_string())?;
-                 } else {
-                      std::fs::write(&full_path, &file_data).map_err(|e| e.to_string())?;
-                 }
-             },
-             AudioFormat::Original => {
-                  std::fs::write(&full_path, &file_data).map_err(|e| e.to_string())?;
-             }
-         }
-    } else if path_lower.ends_with(".dat") || path_lower.ends_with(".dat64") || path_lower.ends_with(".datc64") || path_lower.ends_with(".datl") || path_lower.ends_with(".datl64") {
-         match settings.data_format {
-             DataFormat::Json => {
-                 let mut converted = false;
-                  if let Some(schema) = schema {
-                       let stem = std::path::Path::new(&path_str).file_stem().and_then(|s| s.to_str()).unwrap_or("");
-                       if let Some(table_def) = schema.tables.iter().find(|t| t.name.eq_ignore_ascii_case(stem)) {
-                           if let Ok(r) = crate::dat::reader::DatReader::new(file_data.clone(), path_str.as_str()) {
-                               use serde_json::{Map, Value};
-                               
-                               let mut rows = Vec::new();
-                               for i in 0..r.row_count {
-                                   if let Ok(vals) = r.read_row(i, table_def) {
-                                       let mut map = Map::new();
-                                        for (j, val) in vals.iter().enumerate() {
-                                            if let Some(col) = table_def.columns.get(j) {
-                                                let col_name = col.name.clone().unwrap_or_else(|| format!("Col{}", j));
-                                                let v = r.value_to_json(val, col);
-                                                map.insert(col_name, v);
-                                            }
-                                        }
-                                       rows.push(Value::Object(map));
-                                   }
-                               }
-                               let json_out = Value::Array(rows);
-                               let dest = full_path.with_extension("json");
-                               let s = serde_json::to_string_pretty(&json_out).map_err(|e| e.to_string())?;
-                               std::fs::write(dest, s).map_err(|e| e.to_string())?;
-                               converted = true;
-                           }
-                       }
-                  }
-                 if !converted {
-                       std::fs::write(&full_path, &file_data).map_err(|e| e.to_string())?;
-                 }
-             },
-             DataFormat::Original => {
-                  std::fs::write(&full_path, &file_data).map_err(|e| e.to_string())?;
-             }
-         }
-     } else if path_lower.ends_with(".psg") {
-         match settings.psg_format {
-            PsgFormat::Json => {
-                 let mut converted = false;
-                 if let Ok(psg_file) = crate::dat::psg::parse_psg(&file_data) {
-                     if let Ok(json_val) = serde_json::to_value(&psg_file) {
-                         let dest = full_path.with_extension("json");
-                         let s = serde_json::to_string_pretty(&json_val).map_err(|e| e.to_string())?;
-                         std::fs::write(dest, s).map_err(|e| e.to_string())?;
-                         converted = true; 
-                     }
-                 }
-                 if !converted {
-                      std::fs::write(&full_path, &file_data).map_err(|e| e.to_string())?;
-                 }
-            },
-            PsgFormat::Original => {
-                  std::fs::write(&full_path, &file_data).map_err(|e| e.to_string())?;
+    } else if path_lower.ends_with(".ogg") {
+        match settings.audio_format {
+            AudioFormat::Wav => {
+                let cursor = std::io::Cursor::new(file_data.to_vec());
+                if let Ok(source) = rodio::Decoder::new(cursor) {
+                    use rodio::Source;
+                    let spec = hound::WavSpec {
+                        channels: source.channels(),
+                        sample_rate: source.sample_rate(),
+                        bits_per_sample: 16,
+                        sample_format: hound::SampleFormat::Int,
+                    };
+                    let dest = full_path.with_extension("wav");
+                    let mut writer =
+                        hound::WavWriter::create(dest, spec).map_err(|e| e.to_string())?;
+                    for sample in source {
+                        let _ = writer.write_sample(sample);
+                    }
+                    writer.finalize().map_err(|e| e.to_string())?;
+                } else {
+                    std::fs::write(&full_path, file_data).map_err(|e| e.to_string())?;
+                }
             }
-         }
-        } else if path_lower.ends_with(".png") || path_lower.ends_with(".jpg") || path_lower.ends_with(".jpeg") || path_lower.ends_with(".webp") {
-            std::fs::write(&full_path, &file_data).map_err(|e| e.to_string())?;
-     } else {
-            std::fs::write(&full_path, &file_data).map_err(|e| e.to_string())?;
-     }
+            AudioFormat::Original => {
+                std::fs::write(&full_path, file_data).map_err(|e| e.to_string())?;
+            }
+        }
+    } else if path_lower.ends_with(".dat")
+        || path_lower.ends_with(".dat64")
+        || path_lower.ends_with(".datc64")
+        || path_lower.ends_with(".datl")
+        || path_lower.ends_with(".datl64")
+    {
+        match settings.data_format {
+            DataFormat::Json => {
+                let mut converted = false;
+                if let Some(schema) = schema {
+                    let stem = std::path::Path::new(&path_str)
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("");
+                    if let Some(table_def) = schema
+                        .tables
+                        .iter()
+                        .find(|t| t.name.eq_ignore_ascii_case(stem))
+                    {
+                        if let Ok(r) =
+                            crate::dat::reader::DatReader::new(file_data.to_vec(), path_str)
+                        {
+                            use serde_json::{Map, Value};
 
-    Ok(filename_display)
+                            let mut rows = Vec::new();
+                            for i in 0..r.row_count {
+                                if let Ok(vals) = r.read_row(i, table_def) {
+                                    let mut map = Map::new();
+                                    for (j, val) in vals.iter().enumerate() {
+                                        if let Some(col) = table_def.columns.get(j) {
+                                            let col_name = col
+                                                .name
+                                                .clone()
+                                                .unwrap_or_else(|| format!("Col{}", j));
+                                            let v = r.value_to_json(val, col);
+                                            map.insert(col_name, v);
+                                        }
+                                    }
+                                    rows.push(Value::Object(map));
+                                }
+                            }
+                            let json_out = Value::Array(rows);
+                            let dest = full_path.with_extension("json");
+                            let s = serde_json::to_string_pretty(&json_out)
+                                .map_err(|e| e.to_string())?;
+                            std::fs::write(dest, s).map_err(|e| e.to_string())?;
+                            converted = true;
+                        }
+                    }
+                }
+                if !converted {
+                    std::fs::write(&full_path, file_data).map_err(|e| e.to_string())?;
+                }
+            }
+            DataFormat::Original => {
+                std::fs::write(&full_path, file_data).map_err(|e| e.to_string())?;
+            }
+        }
+    } else if path_lower.ends_with(".psg") {
+        match settings.psg_format {
+            PsgFormat::Json => {
+                let mut converted = false;
+                if let Ok(psg_file) = crate::dat::psg::parse_psg(file_data) {
+                    if let Ok(json_val) = serde_json::to_value(&psg_file) {
+                        let dest = full_path.with_extension("json");
+                        let s =
+                            serde_json::to_string_pretty(&json_val).map_err(|e| e.to_string())?;
+                        std::fs::write(dest, s).map_err(|e| e.to_string())?;
+                        converted = true;
+                    }
+                }
+                if !converted {
+                    std::fs::write(&full_path, file_data).map_err(|e| e.to_string())?;
+                }
+            }
+            PsgFormat::Original => {
+                std::fs::write(&full_path, file_data).map_err(|e| e.to_string())?;
+            }
+        }
+    } else if path_lower.ends_with(".png")
+        || path_lower.ends_with(".jpg")
+        || path_lower.ends_with(".jpeg")
+        || path_lower.ends_with(".webp")
+    {
+        std::fs::write(&full_path, file_data).map_err(|e| e.to_string())?;
+    } else {
+        std::fs::write(&full_path, file_data).map_err(|e| e.to_string())?;
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- group bundled export work by bundle so each worker decompresses a bundle once and exports borrowed slices from the decompressed buffer
- add mmap-backed slice decompression for bundle payloads to avoid per-block compressed data allocations
- avoid extra raw export copies for loose GGPK/Steam files where possible
- cache created parent directories and throttle progress updates in the hot export loop

## Why
Large exports were doing repeated bundle work, avoidable allocations/copies, repeated directory creation checks, and very frequent progress messages. The new path keeps the existing export behavior but reduces redundant work in the extraction hot path.

## Validation
- cargo test --release
- cargo test --release export_armours -- --ignored --nocapture

Local benchmark result: exported 75,473 files in 1.303s with 0 errors.